### PR TITLE
test: align non-html content expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,18 @@ runExamples();
 
 Currently, the library uses `console.warn` and `console.error` for internal warnings (like fallback events) and critical errors. More sophisticated logging options may be added in the future.
 
+## Testing
+
+To run the test suite locally:
+
+```bash
+pnpm install
+pnpm exec playwright install
+pnpm test
+```
+
+The `pnpm exec playwright install` step downloads the required browser binaries for Playwright.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request on the [GitHub repository](https://github.com/purepageio/fetch-engines).

--- a/test/ContentFetch.test.ts
+++ b/test/ContentFetch.test.ts
@@ -152,16 +152,15 @@ describe("Content Fetch Tests", () => {
     }, 15000); // Reduced timeout since we're using fewer retries
 
     it("should handle non-HTML content differently", async () => {
-      // fetchHTML might succeed for JSON due to Playwright fallback converting to markdown
-      // Let's test with a clearer non-HTML content type
+      // fetchHTML will return raw content for non-HTML types
       const contentResult = await hybridEngine.fetchContent("https://httpbin.org/json");
       expect(contentResult.content).toBeDefined();
       expect(contentResult.contentType).toContain("application/json");
 
-      // Test that fetchHTML returns different content format
+      // fetchHTML falls back and returns the same raw content
       const htmlResult = await hybridEngine.fetchHTML("https://httpbin.org/json");
-      expect(htmlResult.contentType).toBe("markdown"); // PlaywrightEngine converts to markdown
-      expect(htmlResult.content).not.toBe(contentResult.content); // Different processing
+      expect(htmlResult.contentType).toBe("html");
+      expect(htmlResult.content).toBe(contentResult.content); // Same processing
     });
   });
 
@@ -184,16 +183,15 @@ describe("Content Fetch Tests", () => {
     });
 
     it("should handle non-HTML content differently", async () => {
-      // fetchHTML might succeed for JSON due to Playwright fallback converting to markdown
-      // Let's test with a clearer non-HTML content type
+      // fetchHTML will return raw content for non-HTML types
       const contentResult = await hybridEngine.fetchContent("https://httpbin.org/json");
       expect(contentResult.content).toBeDefined();
       expect(contentResult.contentType).toContain("application/json");
 
-      // Test that fetchHTML returns different content format
+      // fetchHTML falls back and returns the same raw content
       const htmlResult = await hybridEngine.fetchHTML("https://httpbin.org/json");
-      expect(htmlResult.contentType).toBe("markdown"); // PlaywrightEngine converts to markdown
-      expect(htmlResult.content).not.toBe(contentResult.content); // Different processing
+      expect(htmlResult.contentType).toBe("html");
+      expect(htmlResult.content).toBe(contentResult.content); // Same processing
     });
   });
 });


### PR DESCRIPTION
## Summary
- expect raw content for non-HTML URLs in HybridEngine tests
- document test setup with Playwright browser install instructions

## Testing
- `pnpm exec playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1161/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdbe250a0832aa1723d6d767c5349