### PR TITLE
test: use .js extension for markdown converter import

### DIFF
--- a/test/MarkdownConverter.test.ts
+++ b/test/MarkdownConverter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { MarkdownConverter } from "../src/utils/markdown-converter";
+import { MarkdownConverter } from "../src/utils/markdown-converter.js";
 
 describe("MarkdownConverter", () => {
   it("retains tables without explicit header rows", () => {


### PR DESCRIPTION
## Summary
- fix MarkdownConverter test import to include `.js` extension for NodeNext ESM resolution

## Testing
- `pnpm test test/MarkdownConverter.test.ts`
- `pnpm test test/ContentFetch.test.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1161/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdd936704832a8bbb68df1f2e0c0b