### PR TITLE
refactor: handle headers and content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,18 @@ async function login() {
     password: "password123",
   });
 
-  // postHTML sends the form data using the same stealthy session as fetchHTML
-  const result = await engine.postHTML("https://example.com/login", body, {
-    contentType: "application/x-www-form-urlencoded",
-  });
+  try {
+    // postHTML sends the form data using the same stealthy session as fetchHTML
+    const result = await engine.postHTML("https://example.com/login", body, {
+      contentType: "application/x-www-form-urlencoded",
+    });
 
-  console.log(`Login response status: ${result.statusCode}`);
-  await engine.cleanup();
+    console.log(`Login response status: ${result.statusCode}`);
+  } finally {
+    await engine.cleanup();
+  }
 }
-login();
+login().catch(console.error);
 ```
 
 ### Raw Content Fetching

--- a/src/FetchEngine.ts
+++ b/src/FetchEngine.ts
@@ -10,6 +10,7 @@ import type { IEngine } from "./IEngine.js"; // Added .js extension
 
 import { MarkdownConverter } from "./utils/markdown-converter.js"; // Import the converter
 import { FetchError } from "./errors.js"; // Only import FetchError
+import { DEFAULT_USER_AGENT } from "./constants.js";
 
 /**
  * Custom error class for HTTP errors from FetchEngine.
@@ -59,8 +60,7 @@ export class FetchEngine implements IEngine {
     let response: Response;
     try {
       const baseHeaders = {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "User-Agent": DEFAULT_USER_AGENT,
         Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.9",
       };
@@ -146,8 +146,7 @@ export class FetchEngine implements IEngine {
     let response: Response;
     try {
       const baseHeaders = {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "User-Agent": DEFAULT_USER_AGENT,
         Accept: "*/*", // Accept any content type for raw content fetching
       };
 
@@ -236,8 +235,7 @@ export class FetchEngine implements IEngine {
     let response: Response;
     try {
       const baseHeaders = {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "User-Agent": DEFAULT_USER_AGENT,
         Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.9",
       };
@@ -251,7 +249,11 @@ export class FetchEngine implements IEngine {
         ...callSpecificHeaders,
       };
 
-      if (!finalHeaders["Content-Type"] && body instanceof URLSearchParams) {
+      if (body instanceof FormData) {
+        delete finalHeaders["Content-Type"];
+      } else if (options.contentType) {
+        finalHeaders["Content-Type"] = options.contentType;
+      } else if (!finalHeaders["Content-Type"] && body instanceof URLSearchParams) {
         finalHeaders["Content-Type"] = "application/x-www-form-urlencoded";
       }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,11 @@ export const DEFAULT_HTTP_TIMEOUT = 30000;
 export const SHORT_DELAY_MS = 100;
 export const EVALUATION_TIMEOUT_MS = 1000;
 
+export const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36";
+
 export const COMMON_HEADERS = {
-  "User-Agent":
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+  "User-Agent": DEFAULT_USER_AGENT,
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
   "Accept-Language": "en-US,en;q=0.9",
   "Accept-Encoding": "gzip, deflate, br",

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,7 +231,10 @@ export interface FetchOptions {
  * Options for POST-based requests such as postHTML.
  * Currently identical to FetchOptions.
  */
-export interface PostOptions extends FetchOptions {}
+export interface PostOptions extends FetchOptions {
+  /** Explicit Content-Type for POST requests. */
+  contentType?: string;
+}
 
 /**
  * Options that can be passed per-request to engine.fetchContent().


### PR DESCRIPTION
## Summary
- reuse shared user agent constant
- strip mismatched Content-Type for FormData
- safeguard Playwright markdown conversion for non-HTML responses
- document promise handling and cleanup in login example

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bfffa6f93c832a833319707745d200
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved POST header handling and content-type logic across FetchEngine and PlaywrightEngine. Fixes FormData submissions and prevents markdown conversion on non-HTML responses.

- **Bug Fixes**
  - Strip Content-Type when body is FormData so boundaries are set correctly.
  - Playwright: send FormData as multipart; URLSearchParams still use application/x-www-form-urlencoded.
  - Only convert to markdown and parse title when the response Content-Type is HTML.

- **Refactors**
  - Reuse DEFAULT_USER_AGENT via a shared constant in engines and COMMON_HEADERS.
  - Add PostOptions.contentType for explicit Content-Type overrides.
  - README: wrap login example with try/finally and .catch to ensure cleanup.

<!-- End of auto-generated description by cubic. -->

