### PR TITLE
ci: add automated version bump to workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,15 @@ jobs:
   build-test-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Changed: Only needs read access now
+      contents: write # Needs write to push version bump commit and tags
       id-token: write # Optional: If using OIDC for authentication instead of token
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        # No fetch-depth needed anymore as we don't modify history
+        with:
+          fetch-depth: 0 # Fetch tags/history for version bump + tagging
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -56,6 +58,19 @@ jobs:
 
       # REMOVED: Configure Git step
       # REMOVED: Bump version step
+
+      - name: Automated version bump
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: phips28/gh-action-bump-version@v10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag-prefix: 'v'
+          # Optional inputs (uncomment to customize):
+          # default: 'patch'      # Fallback bump when no keyword found
+          commit-message: 'ci: bump version to {{version}} [skip ci]'
+          # skip-commit: false
+          # skip-tag: false
 
       - name: Build project
         # Build runs after tests pass on the main branch commit (post-merge)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automates semantic version bumping and tagging in the publish workflow on pushes to main. This creates a version commit and tag automatically, reducing manual release steps.

- **New Features**
  - Adds phips28/gh-action-bump-version@v10 with tag-prefix "v" and commit message "ci: bump version to {{version}} [skip ci]".
  - Runs only on push to refs/heads/main.
  - Updates permissions to contents: write and sets checkout fetch-depth: 0 to push commits and tags.
  - Removes manual git config and version bump steps.

<!-- End of auto-generated description by cubic. -->

